### PR TITLE
fix(auth): properly handle Azure AD reset password on iOS

### DIFF
--- a/src/app/core/authentication/oidc-authentication/oidc-authentication.service.ts
+++ b/src/app/core/authentication/oidc-authentication/oidc-authentication.service.ts
@@ -46,12 +46,12 @@ export class OIDCAuthenticationService implements Authenticator {
       this.sessionVault.setValue(this.authResultKey, res);
     } catch (err: any) {
       // eslint-disable-next-line
-      console.log('login error:', +err);
-      const message: string = err.message;
+      console.log('login error:', err);
+      const message: string = err.errorMessage;
       if (
         this.options.clientId === environment.azureConfig.clientId &&
         message !== undefined &&
-        message.startsWith('AADB2C90118')
+        message.includes('AADB2C90118')
       ) {
         // This is to handle the password reset case for Azure AD and is only applicable to Azure  AD
         // The address you pass back is the custom user flow (policy) endpoint


### PR DESCRIPTION
This fixes a typo when logging out the error of a failed login.
It also adjusts to a new error message format to properly detect and parse the Azure error code when resetting a password.